### PR TITLE
feat: optimize Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,12 @@
+.git
+.github
+.gitignore
+
 .env
 .react-router
 .wrangler
 .dev.vars
+docs
 data
 dist
 inputs
@@ -11,3 +16,4 @@ worker-configuration.d.ts
 wrangler.json
 
 Dockerfile
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,14 @@ ARG BASE_IMAGE=node:24.6-alpine
 
 FROM ${BASE_IMAGE} AS base
 WORKDIR /app
+# enable and download pnpm
+RUN corepack enable && pnpm -v
 
 FROM base AS deps
 COPY package.json pnpm-lock.yaml ./
 COPY patches patches
-RUN corepack enable
-RUN pnpm fetch
+RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
+    pnpm fetch
 
 FROM base AS builder
 ARG RETROASSEMBLY_BUILD_TIME_VITE_VERSION
@@ -15,17 +17,17 @@ ENV RETROASSEMBLY_BUILD_TIME_VITE_VERSION=$RETROASSEMBLY_BUILD_TIME_VITE_VERSION
 ENV SKIP_INSTALL_SIMPLE_GIT_HOOKS=true
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
-RUN corepack enable
 RUN pnpm i
 RUN node --run=build
 
 FROM base AS deps-production
 COPY package.json pnpm-lock.yaml ./
 COPY patches patches
-RUN corepack enable
-RUN pnpm i --prod
+RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
+    pnpm i --prod
 
-FROM base AS production
+FROM ${BASE_IMAGE} AS production
+WORKDIR /app
 COPY --from=builder /app/dist/client ./dist/client
 COPY --from=builder /app/dist/scripts ./dist/scripts
 COPY --from=builder /app/src/databases ./src/databases

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
-FROM node:alpine AS base
+ARG BASE_IMAGE=node:24.6-alpine
+
+FROM ${BASE_IMAGE} AS base
+WORKDIR /app
 
 FROM base AS deps
-WORKDIR /app
 COPY package.json pnpm-lock.yaml ./
 COPY patches patches
 RUN corepack enable
@@ -11,7 +13,6 @@ FROM base AS builder
 ARG RETROASSEMBLY_BUILD_TIME_VITE_VERSION
 ENV RETROASSEMBLY_BUILD_TIME_VITE_VERSION=$RETROASSEMBLY_BUILD_TIME_VITE_VERSION
 ENV SKIP_INSTALL_SIMPLE_GIT_HOOKS=true
-WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 RUN corepack enable
@@ -19,14 +20,12 @@ RUN pnpm i
 RUN node --run=build
 
 FROM base AS deps-production
-WORKDIR /app
 COPY package.json pnpm-lock.yaml ./
 COPY patches patches
 RUN corepack enable
 RUN pnpm i --prod
 
 FROM base AS production
-WORKDIR /app
 COPY --from=builder /app/dist/client ./dist/client
 COPY --from=builder /app/dist/scripts ./dist/scripts
 COPY --from=builder /app/src/databases ./src/databases

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,5 +33,7 @@ COPY --from=builder /app/src/databases ./src/databases
 COPY --from=builder /app/dist/client ./dist/client
 COPY --from=builder /app/dist/scripts ./dist/scripts
 COPY --from=deps-production /app/node_modules ./node_modules
+
+VOLUME ["/app/data"]
 EXPOSE 8000
 CMD ["node", "--run=start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,13 +11,13 @@ COPY patches patches
 RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
     pnpm fetch
 
-FROM base AS builder
+FROM deps AS builder
 ARG RETROASSEMBLY_BUILD_TIME_VITE_VERSION
 ENV RETROASSEMBLY_BUILD_TIME_VITE_VERSION=$RETROASSEMBLY_BUILD_TIME_VITE_VERSION
 ENV SKIP_INSTALL_SIMPLE_GIT_HOOKS=true
-COPY --from=deps /app/node_modules ./node_modules
 COPY . .
-RUN pnpm i
+RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
+    pnpm i
 RUN node --run=build
 
 FROM base AS deps-production
@@ -28,10 +28,10 @@ RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
 
 FROM ${BASE_IMAGE} AS production
 WORKDIR /app
+COPY --from=builder /app/package.json ./
+COPY --from=builder /app/src/databases ./src/databases
 COPY --from=builder /app/dist/client ./dist/client
 COPY --from=builder /app/dist/scripts ./dist/scripts
-COPY --from=builder /app/src/databases ./src/databases
-COPY --from=builder /app/package.json ./
 COPY --from=deps-production /app/node_modules ./node_modules
 EXPOSE 8000
 CMD ["node", "--run=start"]


### PR DESCRIPTION
General improvements and best practices for the Dockerfile:

* Use specific tag for `node` (version 24.6), rather than `node:alpine`. While this does not grant exact reproducible builds (the minor version may bump), it's still better than just setting `latest`.
* Refactored the `Dockerfile` to allow specifying a custom Node.js base image using the `BASE_IMAGE` build argument, allows to use other image for build and run.
* Remove duplicated content, share files across stages. Speeds up build process.
* Added `.git`, `.github`, `.gitignore`, and `docs` to `.dockerignore` to reduce build context size.
* Use `cache` for `pnpm`, avoids re-downloading all dependencies each time.
* Implement `VOLUME` option to define the data directory, and allows to run the image directly (as directory will be created on run).